### PR TITLE
fix: use stored config file path for profile switching

### DIFF
--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -32,6 +32,9 @@ export interface MCPConfig {
 
     // External References
     references: Reference[];
+
+    // Config file path (set by loadConfigFromFile for profile switching)
+    configFilePath?: string;
 }
 
 export interface Reference {
@@ -263,7 +266,8 @@ export function loadConfigFromFile(configPath?: string, profileName?: string, si
             tenantId: resolvedProfile.tenantId ?? '',
             authFlow: resolvedProfile.authFlow ?? 'azure_cli',
             applicationInsightsAppId: resolvedProfile.applicationInsightsAppId ?? '',
-            kustoClusterUrl: resolvedProfile.kustoClusterUrl ?? ''
+            kustoClusterUrl: resolvedProfile.kustoClusterUrl ?? '',
+            configFilePath: filePath!
         };
 
         return expandEnvironmentVariables(merged);
@@ -284,7 +288,8 @@ export function loadConfigFromFile(configPath?: string, profileName?: string, si
         port: rawConfig.port ?? 52345,
         workspacePath: rawConfig.workspacePath ?? process.env.BCTB_WORKSPACE_PATH ?? process.cwd(),
         queriesFolder: rawConfig.queriesFolder ?? 'queries',
-        references: rawConfig.references ?? []
+        references: rawConfig.references ?? [],
+        configFilePath: filePath!
     };
 
     return expandEnvironmentVariables(singleConfig);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1375,7 +1375,7 @@ ${extendStatements}
         const path = require('path');
 
         try {
-            const configPath = path.join(this.config.workspacePath, '.bctb-config.json');
+            const configPath = this.config.configFilePath || path.join(this.config.workspacePath, '.bctb-config.json');
 
             if (!fs.existsSync(configPath)) {
                 return {
@@ -1466,8 +1466,8 @@ ${extendStatements}
         const path = require('path');
 
         try {
-            // Check if workspace has a config file
-            const configPath = path.join(this.config.workspacePath, '.bctb-config.json');
+            // Use stored config file path, falling back to workspace discovery
+            const configPath = this.config.configFilePath || path.join(this.config.workspacePath, '.bctb-config.json');
 
             if (!fs.existsSync(configPath)) {
                 return {


### PR DESCRIPTION
## Summary

- `switchProfile()` and `listProfiles()` hardcode the config path as `path.join(workspacePath, '.bctb-config.json')`, ignoring the path resolved via `--config` at startup
- This causes both methods to return "single profile mode" / "No .bctb-config.json found" when the config file has a different name or lives outside `workspacePath`
- Store the resolved config file path on `MCPConfig.configFilePath` during `loadConfigFromFile()` and use it in both methods, falling back to workspace path lookup for backwards compatibility

Fixes #95

## Changes

- **`config.ts`**: Add optional `configFilePath` to `MCPConfig` interface; set it in both multi-profile and single-profile return paths of `loadConfigFromFile()`
- **`server.ts`**: Use `this.config.configFilePath || path.join(...)` in `switchProfile()` and `listProfiles()` instead of the hardcoded path

## Test plan

- [ ] `bctb-mcp start --config /path/to/custom-named-config.json` → `list_profiles` returns `profileMode: "multi"`
- [ ] `switch_profile("other")` succeeds and reinitializes services
- [ ] `list_profiles` after switch shows updated active profile
- [ ] Backwards compat: server started without `--config` (discovery via `.bctb-config.json` in workspace) still works