### PR TITLE
Add npm metadata for MCP package source links

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -2,6 +2,15 @@
     "name": "bc-telemetry-buddy-mcp",
     "version": "3.5.1",
     "description": "Model Context Protocol server for Business Central telemetry",
+    "homepage": "https://github.com/waldo1001/waldo.BCTelemetryBuddy/tree/main/packages/mcp#readme",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/waldo1001/waldo.BCTelemetryBuddy.git",
+        "directory": "packages/mcp"
+    },
+    "bugs": {
+        "url": "https://github.com/waldo1001/waldo.BCTelemetryBuddy/issues"
+    },
     "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/waldo1001"


### PR DESCRIPTION
## Summary
- add package-level homepage, repository.directory, and bugs metadata for `bc-telemetry-buddy-mcp`
- point npm users directly to the MCP package source folder and issue tracker

## Validation
- `node -e "const p=require('./packages/mcp/package.json'); for (const k of ['homepage','repository','bugs']) { if (!p[k]) throw new Error('missing '+k); } if (p.repository.directory !== 'packages/mcp') throw new Error('bad directory');"`
- `npm pack --dry-run --ignore-scripts ./packages/mcp`
- `git diff --check`