### PR TITLE
chore(deps): remediate main's cleanly-fixable transitive advisories

### DIFF
--- a/docs/plans/main-transitive-vuln-remediation.md
+++ b/docs/plans/main-transitive-vuln-remediation.md
@@ -1,0 +1,75 @@
+---
+topic: main-transitive-vuln-remediation
+status: approved
+created: 2026-07-21
+spec: spec-lite
+---
+
+## Spec-lite
+- Intent: Reduce `main`'s latent transitive-dependency advisories by pinning the **cleanly-fixable leaf packages** (a patched version exists in the same major line) via a root npm `overrides` block, and **document the remainder** (the OpenTelemetry / Azure Monitor / applicationinsights cluster and major-bump-only deps) as upstream-pending accepted risk. No application code changes.
+- **AC1:** Given `main`'s current tree, When the `overrides` block below is added and `npm install` regenerates the lockfile, Then each targeted package resolves to a patched version and `npm audit` no longer flags any of the 8 targeted packages.
+- **AC2:** Given the change, When `npm ci`, `npm run build`, and `npm test` run, Then they pass (no regression in load-bearing deps — axios, gRPC, protobufjs, markdown-it).
+- **AC3:** Given the excluded advisories, When the remediation lands, Then a security-debt doc records every remaining moderate+ advisory, its fixability, and why it is deferred (upstream-pending or major-bump breakage risk).
+- Eligibility: chore, blast radius `low-risk`.
+
+## Task
+Add a root `package.json` npm `overrides` block pinning 8 cleanly-fixable leaf transitive deps to patched versions on `main`, verify build+tests, and document the deferred remainder.
+
+## Scope boundary
+- IN: root `package.json` (`overrides`), `package-lock.json` (regenerated), a new security-debt doc, this plan file.
+- OUT: any `packages/**/src` source. The OTel / Azure Monitor / applicationinsights cluster (no clean forward fix — would need an `applicationinsights` major downgrade). Major-bump / multi-major-line deps (uuid, undici, fast-uri, linkify-it, @nevware21/ts-utils, brace-expansion, js-yaml) — breakage risk, deferred. No `applicationinsights` downgrade. No workflow changes.
+
+## Files to create / touch
+- `package.json` (add `overrides`)
+- `package-lock.json` (regenerated — not hand-edited)
+- `docs/security/dependency-debt.md` (new — deferred-advisory register)
+- `docs/plans/main-transitive-vuln-remediation.md` (this file)
+
+## Interface
+No public interface change. New `package.json` field:
+```json
+"overrides": {
+  "hono": "^4.12.31",
+  "protobufjs": "^7.6.5",
+  "form-data": "^4.0.6",
+  "tmp": "^0.2.7",
+  "qs": "^6.15.3",
+  "@grpc/grpc-js": "^1.14.4",
+  "markdown-it": "^14.3.0",
+  "axios": "^1.18.1"
+}
+```
+Each target is a patch/minor bump within the package's existing major (advisory minimums: hono <=4.12.24, protobufjs <=7.6.4, form-data 4.0.0-4.0.5, tmp <0.2.6, qs 6.11.1-6.15.1, @grpc/grpc-js 1.14.0-1.14.3, markdown-it <=14.1.1, axios 1.0.0-1.17.0). `markdown-it@^14.3.0` is expected to also clear the `linkify-it` advisory transitively; if it does not, `linkify-it` moves to the deferred register (no same-major patch).
+
+## Dependencies
+- `@grpc/proto-loader` requires `protobufjs: ^7.5.5` → `^7.6.5` satisfies it (stay in 7.x; do NOT force 8.x). `main` has no protobufjs 8.x consumer.
+- All other overrides stay within the consumers' declared major ranges.
+
+## RED test list
+No new unit test — dependency-resolution change. Verification is external:
+- **AC1:** `npm audit --json` shows none of the 8 targeted packages flagged; `npm ls <pkg>` shows the patched version, no `invalid`. — seams: none
+- **AC2:** `npm ci` exit 0 (lockfile in sync) + `npm run build` exit 0 + `npm test` all suites pass. — seams: none
+- **AC3:** `docs/security/dependency-debt.md` exists and lists every remaining moderate+ advisory with fixability + deferral reason. — seams: none
+
+## Telemetry (Rule 13)
+N/A — no new feature/tool, no code path added.
+
+## Open questions / assumptions
+- Assumption: global overrides are safe on `main` because no current consumer needs a conflicting major (verified for protobufjs). If any override yields `ELSPROBLEMS`/`invalid` or fails tests, it is dropped to the deferred register and reported — never forced.
+- Assumption: lands on branch `chore/deps-main-vuln-remediation` → PR to `main` (not a direct push to `main`).
+
+## Risks
+- axios / @grpc/grpc-js / protobufjs are load-bearing (HTTP client, telemetry export). Mitigated: all are patch/minor within-major bumps; full build + test suite gates them; any failure drops that override.
+- `npm install` could pull incidental transitive churn. Mitigated: review the lockfile diff; keep it to the targeted packages + their strict requirements.
+- markdown-it 14.1.1 → 14.3.0 could alter KB/doc rendering. Mitigated: within-14.x minor; existing tests + KB-index validation guard it.
+
+## Blast radius / breakage prediction
+- **Rating:** `low-risk`
+  - Only patch/minor within-major bumps of transitive deps; no API/schema/config/on-disk-format change. Rollback = revert one commit.
+  - Load-bearing deps (axios, gRPC, protobufjs) are gated by the full test suite; any regression fails CI before merge.
+- **Who/what could break:** CI build/test; in the worst case the MCP HTTP client (axios) or telemetry export (gRPC/protobufjs). Not: MCP tool contracts, extension users, saved queries, KB cache, on-disk formats.
+- **Detection:** `npm ci` + build + test on the PR; post-merge, an MCP query failure (axios) or missing telemetry (gRPC) would surface it.
+
+## Out-of-scope follow-ups
+- **Deferred advisories** (recorded in `docs/security/dependency-debt.md`): the OTel/Azure Monitor/applicationinsights cluster (~30, upstream-pending) and major-bump deps (uuid, undici, fast-uri, linkify-it, @nevware21/ts-utils, brace-expansion, js-yaml). Revisit when OTel/appinsights ship patched releases, or in a dedicated major-bump cycle with per-dep testing.
+- Add a scheduled `npm audit` / Dependabot job so `main`'s transitive vulns surface continuously.

--- a/docs/security/dependency-debt.md
+++ b/docs/security/dependency-debt.md
@@ -1,0 +1,75 @@
+# Dependency Security Debt
+
+Register of known transitive-dependency advisories on `main` that are **not** currently
+remediated, why they're deferred, and when to revisit. Companion to the remediation in
+[docs/plans/main-transitive-vuln-remediation.md](../plans/main-transitive-vuln-remediation.md).
+
+- **Last reviewed:** 2026-07-21 (`npm audit`)
+- **Snapshot at review:** 40 moderate+ advisories remaining (8 high, 30 moderate, 2 low) — down from 50 before remediation.
+- These are **latent**: `dependency-review-action` only runs on PRs and only flags the PR *diff*, so `main`'s unchanged transitive deps block no CI. A PR that regenerates the lockfile can surface any of these (that is exactly what happened on PR #127).
+
+## Remediated (this pass)
+
+Pinned to patched versions within the existing major line — see the `overrides` block in the root
+[package.json](../../package.json) plus the `axios` direct-dependency bump in
+`packages/shared` and `packages/extension`:
+
+| Package | → Version | Advisory range cleared |
+|---|---|---|
+| hono | ^4.12.31 | ≤4.12.24 |
+| protobufjs | ^7.6.5 | ≤7.6.4 |
+| form-data | ^4.0.6 | 4.0.0–4.0.5 |
+| tmp | ^0.2.7 | <0.2.6 |
+| qs | ^6.15.3 | 6.11.1–6.15.1 |
+| @grpc/grpc-js | ^1.14.4 | 1.14.0–1.14.3 |
+| markdown-it | ^14.3.0 | ≤14.1.1 (also cleared `linkify-it` transitively) |
+| axios | ^1.18.1 (direct-dep bump) | 1.0.0–1.17.0 |
+
+## Deferred
+
+### 1. OpenTelemetry / Azure Monitor / applicationinsights cluster (~30)
+
+All pulled transitively by the direct dependency `applicationinsights@^3.12.0`
+(`packages/mcp`, required for Rule 13 telemetry). Advisories:
+
+- `@azure/monitor-opentelemetry` (high, ≤1.18.1), `@opentelemetry/sdk-node` (high, ≤0.218.0),
+  `@opentelemetry/exporter-prometheus` (high, ≤0.218.0), plus ~27 moderate `@opentelemetry/*`,
+  `@azure/monitor-opentelemetry-exporter`, `@azure/opentelemetry-instrumentation-azure-sdk`,
+  `@azure/functions`, and `applicationinsights` itself.
+
+**Why deferred:** the advisory ranges (`<=0.218.0`, `<=2.7.1`, `<2.8.0`) reach the *current
+latest* releases — there is no forward-patched version to move to. `npm audit`'s only concrete
+"fix" is downgrading `applicationinsights` to **2.9.8 (a major downgrade)**, which would regress
+the telemetry pipeline. Several entries report `fixAvailable: true`, but that reflects a
+dependency-graph rearrangement npm cannot actually satisfy from the registry — not an available
+patched release.
+
+**Revisit when:** the OpenTelemetry JS ecosystem and `@azure/monitor-opentelemetry` /
+`applicationinsights` ship releases outside these ranges. Then bump `applicationinsights` and let
+the stack update; no override needed.
+
+### 2. Major-bump / multi-line deps (deferred — breakage risk)
+
+Fixing these safely needs a new major or a multi-major-line scoped override, each requiring
+per-dependency testing beyond this pass's scope (the "safe subset" was chosen deliberately):
+
+| Package | Advisory range | Note |
+|---|---|---|
+| uuid | <11.1.1 | in-tree 8.3.2; v10+ is ESM-only — API-breaking bump |
+| @azure/msal-node | ≤5.1.4 | fix is msal-node 5.4.1 (major); it's a direct dep of `packages/shared` |
+| undici | 7.0.0–7.27.2 | fix likely in 8.x (major) |
+| fast-uri | ≤3.1.1 | under `ajv`; fix may require 4.x (major) |
+| brace-expansion | <1.1.16 \|\| ≥3.0.0 <5.0.7 | two separate major lines in-tree (1.x + 5.x) |
+| js-yaml | ≤3.14.2 \|\| 4.0.0–4.2.0 | two major lines in-tree (3.x + 4.x) |
+| @nevware21/ts-utils | ≤0.13.0 | pre-1.0; under applicationinsights |
+| @azure/identity | broad range | large advisory span; needs targeted version check |
+
+Some of these report `npm fix: true` (in-range) and may turn out to be cleanly fixable — they are
+**candidates for a follow-up "aggressive" pass** with per-dep build+test verification, not fixed
+here by design.
+
+## Recommended follow-ups
+- Add a scheduled `npm audit` (or Dependabot) job so `main`'s transitive advisories surface
+  continuously instead of only when a PR happens to regenerate the lockfile.
+- Re-run this review when `applicationinsights` publishes a release on patched OpenTelemetry, to
+  clear the bulk of the cluster in one bump.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,9 +1362,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.1.tgz",
-            "integrity": "sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.8.0",
@@ -4442,31 +4442,24 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -5451,17 +5444,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
-        "node_modules/axios": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
         "node_modules/azure-devops-node-api": {
             "version": "12.5.0",
             "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
@@ -5926,6 +5908,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
                 "get-intrinsic": "^1.3.0"
@@ -6998,21 +6981,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7180,15 +7148,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -7537,9 +7506,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -7548,9 +7518,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.18",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-            "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+            "version": "4.12.31",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -9614,10 +9584,21 @@
             "dev": true
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
             }
@@ -9793,15 +9774,25 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -10144,6 +10135,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10726,24 +10718,23 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -10813,12 +10804,13 @@
             ]
         },
         "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -11429,13 +11421,14 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },
@@ -11447,12 +11440,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -11465,6 +11459,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -11482,6 +11477,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -12076,10 +12072,11 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }
@@ -12271,7 +12268,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uglify-js": {
             "version": "3.19.3",
@@ -12769,7 +12767,7 @@
             "dependencies": {
                 "@bctb/shared": "file:../shared",
                 "@vscode/extension-telemetry": "^1.2.0",
-                "axios": "^1.16.0"
+                "axios": "^1.18.1"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
@@ -12798,6 +12796,43 @@
             "dev": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
+            }
+        },
+        "packages/extension/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "packages/extension/node_modules/axios": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "packages/extension/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "packages/extension/node_modules/undici-types": {
@@ -12990,7 +13025,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@azure/msal-node": "^3.8.0",
-                "axios": "^1.16.0",
+                "axios": "^1.18.1",
                 "lru-cache": "^10.1.0"
             },
             "devDependencies": {
@@ -13033,6 +13068,18 @@
                 "undici-types": "~6.21.0"
             }
         },
+        "packages/shared/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "packages/shared/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -13043,6 +13090,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "packages/shared/node_modules/axios": {
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+            "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "packages/shared/node_modules/expect": {
@@ -13059,6 +13118,19 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "packages/shared/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "packages/shared/node_modules/jest-diff": {
@@ -13833,7 +13905,7 @@
                 "@azure/msal-node": "^3.8.0",
                 "@types/jest": "^29.5.0",
                 "@types/node": "^22.18.11",
-                "axios": "^1.16.0",
+                "axios": "^1.18.1",
                 "jest": "^29.7.0",
                 "lru-cache": "^10.1.0",
                 "rimraf": "^6.0.1",
@@ -13869,11 +13941,30 @@
                         "undici-types": "~6.21.0"
                     }
                 },
+                "agent-base": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+                    "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+                    "requires": {
+                        "debug": "4"
+                    }
+                },
                 "ansi-styles": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
                     "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
                     "dev": true
+                },
+                "axios": {
+                    "version": "1.18.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+                    "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+                    "requires": {
+                        "follow-redirects": "^1.16.0",
+                        "form-data": "^4.0.5",
+                        "https-proxy-agent": "^5.0.1",
+                        "proxy-from-env": "^2.1.0"
+                    }
                 },
                 "expect": {
                     "version": "29.7.0",
@@ -13886,6 +13977,15 @@
                         "jest-matcher-utils": "^29.7.0",
                         "jest-message-util": "^29.7.0",
                         "jest-util": "^29.7.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+                    "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+                    "requires": {
+                        "agent-base": "6",
+                        "debug": "4"
                     }
                 },
                 "jest-diff": {
@@ -14150,9 +14250,9 @@
             "optional": true
         },
         "@grpc/grpc-js": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.1.tgz",
-            "integrity": "sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "requires": {
                 "@grpc/proto-loader": "^0.8.0",
                 "@js-sdsl/ordered-map": "^4.4.2"
@@ -14165,7 +14265,7 @@
             "requires": {
                 "lodash.camelcase": "^4.3.0",
                 "long": "^5.0.0",
-                "protobufjs": "^7.5.3",
+                "protobufjs": "^7.6.5",
                 "yargs": "^17.7.2"
             },
             "dependencies": {
@@ -15061,7 +15161,7 @@
                 "eventsource-parser": "^3.0.0",
                 "express": "^5.2.1",
                 "express-rate-limit": "^8.2.1",
-                "hono": "^4.11.4",
+                "hono": "^4.12.31",
                 "jose": "^6.1.3",
                 "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
@@ -15090,7 +15190,7 @@
                         "http-errors": "^2.0.0",
                         "iconv-lite": "^0.7.0",
                         "on-finished": "^2.4.1",
-                        "qs": "^6.14.1",
+                        "qs": "^6.15.3",
                         "raw-body": "^3.0.1",
                         "type-is": "^2.0.1"
                     }
@@ -15130,7 +15230,7 @@
                         "once": "^1.4.0",
                         "parseurl": "^1.3.3",
                         "proxy-addr": "^2.0.7",
-                        "qs": "^6.14.0",
+                        "qs": "^6.15.3",
                         "range-parser": "^1.2.1",
                         "router": "^2.2.0",
                         "send": "^1.1.0",
@@ -15334,7 +15434,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.208.0.tgz",
             "integrity": "sha512-AmZDKFzbq/idME/yq68M155CJW1y056MNBekH9OZewiZKaqgwYN4VYfn3mXVPftYsfrCM2r4V6tS8H2LmfiDCg==",
             "requires": {
-                "@grpc/grpc-js": "^1.7.1",
+                "@grpc/grpc-js": "^1.14.4",
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/otlp-exporter-base": "0.208.0",
                 "@opentelemetry/otlp-grpc-exporter-base": "0.208.0",
@@ -15370,7 +15470,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -15449,7 +15549,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -15469,7 +15569,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.208.0.tgz",
             "integrity": "sha512-YbEnk7jjYmvhIwp2xJGkEvdgnayrA2QSr28R1LR1klDPvCxsoQPxE6TokDbQpoCEhD3+KmJVEXfb4EeEQxjymg==",
             "requires": {
-                "@grpc/grpc-js": "^1.7.1",
+                "@grpc/grpc-js": "^1.14.4",
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "0.208.0",
                 "@opentelemetry/otlp-exporter-base": "0.208.0",
@@ -15519,7 +15619,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -15630,7 +15730,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.208.0.tgz",
             "integrity": "sha512-E/eNdcqVUTAT7BC+e8VOw/krqb+5rjzYkztMZ/o+eyJl+iEY6PfczPXpwWuICwvsm0SIhBoh9hmYED5Vh5RwIw==",
             "requires": {
-                "@grpc/grpc-js": "^1.7.1",
+                "@grpc/grpc-js": "^1.14.4",
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/otlp-exporter-base": "0.208.0",
                 "@opentelemetry/otlp-grpc-exporter-base": "0.208.0",
@@ -15667,7 +15767,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -15763,7 +15863,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -15923,7 +16023,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.208.0.tgz",
             "integrity": "sha512-fGvAg3zb8fC0oJAzfz7PQppADI2HYB7TSt/XoCaBJFi1mSquNUjtHXEoviMgObLAa1NRIgOC1lsV1OUKi+9+lQ==",
             "requires": {
-                "@grpc/grpc-js": "^1.7.1",
+                "@grpc/grpc-js": "^1.14.4",
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/otlp-exporter-base": "0.208.0",
                 "@opentelemetry/otlp-transformer": "0.208.0"
@@ -15957,7 +16057,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -15983,7 +16083,7 @@
                 "@opentelemetry/sdk-logs": "0.204.0",
                 "@opentelemetry/sdk-metrics": "2.1.0",
                 "@opentelemetry/sdk-trace-base": "2.1.0",
-                "protobufjs": "^7.3.0"
+                "protobufjs": "^7.6.5"
             },
             "dependencies": {
                 "@opentelemetry/core": {
@@ -16208,7 +16308,7 @@
                         "@opentelemetry/sdk-logs": "0.208.0",
                         "@opentelemetry/sdk-metrics": "2.2.0",
                         "@opentelemetry/sdk-trace-base": "2.2.0",
-                        "protobufjs": "^7.3.0"
+                        "protobufjs": "^7.6.5"
                     }
                 },
                 "@opentelemetry/sdk-logs": {
@@ -16300,28 +16400,22 @@
             "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
         },
         "@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="
         },
         "@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "requires": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "@protobufjs/float": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-        },
-        "@protobufjs/inquire": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="
         },
         "@protobufjs/path": {
             "version": "1.1.2",
@@ -16894,20 +16988,20 @@
                 "cheerio": "^1.0.0-rc.9",
                 "cockatiel": "^3.1.2",
                 "commander": "^12.1.0",
-                "form-data": "^4.0.0",
+                "form-data": "^4.0.6",
                 "glob": "^11.0.0",
                 "hosted-git-info": "^4.0.2",
                 "jsonc-parser": "^3.2.0",
                 "keytar": "^7.7.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^14.1.0",
+                "markdown-it": "^14.3.0",
                 "mime": "^1.3.4",
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
                 "secretlint": "^10.1.2",
                 "semver": "^7.5.2",
-                "tmp": "^0.2.3",
+                "tmp": "^0.2.7",
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^4.0.1",
                 "xml2js": "^0.5.0",
@@ -17127,16 +17221,6 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
-        "axios": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-            "requires": {
-                "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
-                "proxy-from-env": "^2.1.0"
-            }
-        },
         "azure-devops-node-api": {
             "version": "12.5.0",
             "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
@@ -17270,7 +17354,7 @@
                 "@vscode/extension-telemetry": "^1.2.0",
                 "@vscode/test-electron": "^2.3.0",
                 "@vscode/vsce": "^3.2.1",
-                "axios": "^1.16.0",
+                "axios": "^1.18.1",
                 "esbuild": "^0.27.0",
                 "jest": "^29.7.0",
                 "rimraf": "^6.0.1",
@@ -17285,6 +17369,34 @@
                     "dev": true,
                     "requires": {
                         "undici-types": "~6.21.0"
+                    }
+                },
+                "agent-base": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+                    "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+                    "requires": {
+                        "debug": "4"
+                    }
+                },
+                "axios": {
+                    "version": "1.18.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+                    "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+                    "requires": {
+                        "follow-redirects": "^1.16.0",
+                        "form-data": "^4.0.5",
+                        "https-proxy-agent": "^5.0.1",
+                        "proxy-from-env": "^2.1.0"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+                    "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+                    "requires": {
+                        "agent-base": "6",
+                        "debug": "4"
                     }
                 },
                 "undici-types": {
@@ -17483,7 +17595,7 @@
                 "http-errors": "~2.0.1",
                 "iconv-lite": "~0.4.24",
                 "on-finished": "~2.4.1",
-                "qs": "~6.15.1",
+                "qs": "^6.15.3",
                 "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
                 "unpipe": "~1.0.0"
@@ -18363,7 +18475,7 @@
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "~6.14.0",
+                "qs": "^6.15.3",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
                 "send": "~0.19.0",
@@ -18387,14 +18499,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-                },
-                "qs": {
-                    "version": "6.14.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-                    "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-                    "requires": {
-                        "side-channel": "^1.1.0"
-                    }
                 }
             }
         },
@@ -18531,15 +18635,15 @@
             }
         },
         "form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             }
         },
         "forwarded": {
@@ -18770,17 +18874,17 @@
             }
         },
         "hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "requires": {
                 "function-bind": "^1.1.2"
             }
         },
         "hono": {
-            "version": "4.12.18",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-            "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="
+            "version": "4.12.31",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg=="
         },
         "hosted-git-info": {
             "version": "4.1.0",
@@ -20352,9 +20456,9 @@
             "dev": true
         },
         "linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
             "dev": true,
             "requires": {
                 "uc.micro": "^2.0.0"
@@ -20499,14 +20603,14 @@
             }
         },
         "markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+            "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -21181,22 +21285,21 @@
             }
         },
         "protobufjs": {
-            "version": "7.5.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "dependencies": {
                 "long": {
@@ -21244,11 +21347,12 @@
             "dev": true
         },
         "qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "requires": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             }
         },
         "queue-microtask": {
@@ -21671,24 +21775,24 @@
             "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
         },
         "side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "requires": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             }
         },
         "side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "requires": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             }
         },
         "side-channel-map": {
@@ -22143,9 +22247,9 @@
             }
         },
         "tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true
         },
         "tmpl": {
@@ -22246,7 +22350,7 @@
             "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
             "dev": true,
             "requires": {
-                "qs": "^6.9.1",
+                "qs": "^6.15.3",
                 "tunnel": "0.0.6",
                 "underscore": "^1.12.1"
             }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,14 @@
     "devDependencies": {
         "@types/node": "^18.0.0",
         "typescript": "^5.3.0"
+    },
+    "overrides": {
+        "hono": "^4.12.31",
+        "protobufjs": "^7.6.5",
+        "form-data": "^4.0.6",
+        "tmp": "^0.2.7",
+        "qs": "^6.15.3",
+        "@grpc/grpc-js": "^1.14.4",
+        "markdown-it": "^14.3.0"
     }
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -311,7 +311,7 @@
     "dependencies": {
         "@bctb/shared": "file:../shared",
         "@vscode/extension-telemetry": "^1.2.0",
-        "axios": "^1.16.0"
+        "axios": "^1.18.1"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@azure/msal-node": "^3.8.0",
-        "axios": "^1.16.0",
+        "axios": "^1.18.1",
         "lru-cache": "^10.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
## What

Pins 8 leaf transitive dependencies to patched versions within their existing major line, clearing the advisories on `main` that have a **safe forward fix**. This is the security-hygiene pass approved after PR #127 surfaced that `main` carries latent transitive advisories (dependency-review only flags PR diffs, so `main`'s never showed).

| Package | → Version | Mechanism | Advisory cleared |
|---|---|---|---|
| hono | ^4.12.31 | root override | ≤4.12.24 |
| protobufjs | ^7.6.5 | root override | ≤7.6.4 (stays 7.x for gRPC) |
| form-data | ^4.0.6 | root override | 4.0.0–4.0.5 |
| tmp | ^0.2.7 | root override | <0.2.6 |
| qs | ^6.15.3 | root override | 6.11.1–6.15.1 |
| @grpc/grpc-js | ^1.14.4 | root override | 1.14.0–1.14.3 |
| markdown-it | ^14.3.0 | root override | ≤14.1.1 (also clears `linkify-it`) |
| axios | ^1.18.1 | direct-dep bump (`shared` + `extension`) | 1.0.0–1.17.0 |

**`npm audit`: 50 → 40** (high 15 → 8). `npm ci` + `npm run build` + full test suite (1,590 tests) pass.

## What's deferred (and why)

Recorded in [`docs/security/dependency-debt.md`](docs/security/dependency-debt.md):

- **OpenTelemetry / Azure Monitor / applicationinsights cluster (~30)** — advisory ranges reach the *current latest* releases; no forward-patched version exists. npm's only "fix" is downgrading `applicationinsights` to 2.9.8 (major), which would regress Rule 13 telemetry. Revisit when the OTel/appinsights upstream ships patched releases.
- **Major-bump / multi-line deps** (uuid, undici, fast-uri, brace-expansion, js-yaml, @nevware21/ts-utils, @azure/msal-node, @azure/identity) — need a new major or multi-major-line scoped overrides with per-dep testing. Deliberately out of the approved "safe subset" scope; candidates for a follow-up pass.

## Blast radius

`low-risk` — patch/minor within-major bumps only; no API/schema/config/on-disk-format change. Load-bearing deps (axios, gRPC, protobufjs) gated by the full test suite. Rollback = revert one commit.

Plan: [`docs/plans/main-transitive-vuln-remediation.md`](docs/plans/main-transitive-vuln-remediation.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)